### PR TITLE
Depend on correct jupyter-client branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup_args = dict(
     ],
     install_requires=[
         'jupyter_client',
-        'jupyter_client @ git+https://github.com/kevin-bates/jupyter_client@env-provisioning',
+        'jupyter_client>=7.0.0a1',
         'paramiko>=2.4.0',
         'pexpect>=4.2.0',
         'pycryptodomex>=3.9.7',

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup_args = dict(
     ],
     install_requires=[
         'jupyter_client',
+        'jupyter_client @ git+https://github.com/kevin-bates/jupyter_client@env-provisioning',
         'paramiko>=2.4.0',
         'pexpect>=4.2.0',
         'pycryptodomex>=3.9.7',


### PR DESCRIPTION
If my understanding is correct, this repo depends on https://github.com/kevin-bates/jupyter_client/tree/env-provisioning