### PR TITLE
Issue warning when missing extras are detected, fix impersonation config

### DIFF
--- a/remote_provisioners/cli/base_specapp.py
+++ b/remote_provisioners/cli/base_specapp.py
@@ -134,9 +134,14 @@ Default = {DEFAULT_INIT_MODE}.""")
 
     def start(self):
         """Drive the kernel specification creation."""
+        self.detect_missing_extras()
         self.validate_parameters()
         self._assemble_kernel_specs()
         self._finalize_kernel_json()
+
+    def detect_missing_extras(self):
+        """Issues a warning message whenever an "extra" library is detected as missing."""
+        pass
 
     def validate_parameters(self):
         """

--- a/remote_provisioners/cli/docker_specapp.py
+++ b/remote_provisioners/cli/docker_specapp.py
@@ -6,6 +6,7 @@ from traitlets import Unicode, Bool, default
 from traitlets.config.application import Application
 
 from .._version import __version__
+from ..docker_swarm import
 from .base_specapp import BaseSpecApp, DEFAULT_LANGUAGE, PYTHON, SCALA, R
 
 
@@ -76,6 +77,15 @@ enabled for Spark usage, this image will be the driver image. (RP_IMAGE_NAME env
         'swarm': ({'DockerSpecApp': {'swarm': True}}, "Install kernel for use within a Docker Swarm cluster."),
     }
     flags.update(BaseSpecApp.super_flags)
+
+    def detect_missing_extras(self):
+        """Issues a warning message whenever an "extra" library is detected as missing."""
+        try:
+            import docker
+        except ImportError:
+            self.log.warning("The extra package 'docker' is not installed in this environment and is required.  "
+                             "Ensure that remote_provisioners is installed by specifying the extra 'docker' "
+                             "(e.g., pip install 'remote_provisioners[docker]').")
 
     def validate_parameters(self):
         """Validate input parameters and prepare for their injection into templated files."""

--- a/remote_provisioners/cli/k8s_specapp.py
+++ b/remote_provisioners/cli/k8s_specapp.py
@@ -92,6 +92,16 @@ Spark-enabled kernel specifications.  (RP_EXECUTOR_IMAGE_NAME env var)""")
     flags = {}
     flags.update(BaseSpecApp.super_flags)
 
+    def detect_missing_extras(self):
+        """Issues a warning message whenever an "extra" library is detected as missing."""
+        try:
+            import kubernetes
+            import jinja2
+        except ImportError:
+            self.log.warning("At least one of the extra packages 'kubernetes' or 'jinja2' are not installed in "
+                             "this environment and are required.  Ensure that remote_provisioners is installed "
+                             "by specifying the extra 'k8s' (e.g., pip install 'remote_provisioners[k8s]').")
+
     def validate_parameters(self):
         """Validate input parameters and prepare for their injection into templated files."""
         super().validate_parameters()

--- a/remote_provisioners/cli/yarn_specapp.py
+++ b/remote_provisioners/cli/yarn_specapp.py
@@ -115,6 +115,15 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
     }
     flags.update(BaseSpecApp.super_flags)
 
+    def detect_missing_extras(self):
+        """Issues a warning message whenever an "extra" library is detected as missing."""
+        try:
+            import yarn_api_client
+        except ImportError:
+            self.log.warning("The extra package 'yarn_api_client'is not installed in this environment and is "
+                             "required.  Ensure that remote_provisioners is installed by specifying the "
+                             "extra 'yarn' (e.g., pip install 'remote_provisioners[yarn]').")
+
     def validate_parameters(self):
         """Validate input parameters and prepare for their injection into templated files."""
         super().validate_parameters()

--- a/remote_provisioners/config_mixin.py
+++ b/remote_provisioners/config_mixin.py
@@ -6,7 +6,7 @@ import os
 
 from tornado.log import LogFormatter
 
-from traitlets import default, Set, Unicode, Integer
+from traitlets import default, Bool, Integer, Set, Unicode
 from traitlets.config import Configurable
 
 
@@ -80,6 +80,16 @@ enforcement.  (RP_PORT_RANGE env var)""")
     # @default('conductor_endpoint')
     # def conductor_endpoint_default(self):
     #     return os.getenv(self.conductor_endpoint_env, self.conductor_endpoint_default_value)
+
+    # Impersonation enabled
+    impersonation_enabled_env = 'RP_IMPERSONATION_ENABLED'
+    impersonation_enabled = Bool(False, config=True,
+                                 help="""Indicates whether impersonation will be performed during kernel launch.
+                                 (RP_IMPERSONATION_ENABLED env var)""")
+
+    @default('impersonation_enabled')
+    def impersonation_enabled_default(self):
+        return bool(os.getenv(self.impersonation_enabled_env, 'false').lower() == 'true')
 
     launch_timeout_env = 'RP_LAUNCH_TIMEOUT'
     launch_timeout_default_value = 30

--- a/remote_provisioners/k8s.py
+++ b/remote_provisioners/k8s.py
@@ -7,10 +7,18 @@ import logging
 import re
 
 import urllib3
-
-from kubernetes import client, config
-from kubernetes.client.rest import ApiException
 from typing import Any, Dict, Optional, Set
+
+try:
+    from kubernetes import client, config
+    from kubernetes.client.rest import ApiException
+    from jinja2 import Environment  # noqa - used by launcher so check presence here
+except ImportError:
+    logging.warning("At least one of the extra packages 'kubernetes' or 'jinja2' are not installed in "
+                    "this environment and are required.  Ensure that remote_provisioners is installed "
+                    "by specifying the extra 'k8s' (e.g., pip install 'remote_provisioners[k8s]').")
+    raise
+
 
 from .container import ContainerProvisioner
 

--- a/remote_provisioners/yarn.py
+++ b/remote_provisioners/yarn.py
@@ -13,7 +13,14 @@ import time
 
 from traitlets import default, Unicode, Bool
 from typing import Any, Dict, List, Optional, Tuple
-from yarn_api_client.resource_manager import ResourceManager
+
+try:
+    from yarn_api_client.resource_manager import ResourceManager
+except ImportError:
+    logging.warning("The extra package 'yarn_api_client'is not installed in this environment and is "
+                    "required.  Ensure that remote_provisioners is installed by specifying the "
+                    "extra 'yarn' (e.g., pip install 'remote_provisioners[yarn]').")
+    raise
 
 from .config_mixin import poll_interval, max_poll_attempts
 from .remote_provisioner import RemoteProvisionerBase
@@ -67,16 +74,6 @@ class YarnProvisioner(RemoteProvisionerBase):
     def yarn_endpoint_security_enabled_default(self):
         return bool(os.getenv(self.yarn_endpoint_security_enabled_env,
                               self.yarn_endpoint_security_enabled_default_value))
-
-    # Impersonation enabled - TODO - Applies to Yarn
-    impersonation_enabled_env = 'RP_IMPERSONATION_ENABLED'
-    impersonation_enabled = Bool(False, config=True,
-                                 help="""Indicates whether impersonation will be performed during kernel launch.
-                                 (RP_IMPERSONATION_ENABLED env var)""")
-
-    @default('impersonation_enabled')
-    def impersonation_enabled_default(self):
-        return bool(os.getenv(self.impersonation_enabled_env, 'false').lower() == 'true')
 
     initial_states = {'NEW', 'SUBMITTED', 'ACCEPTED', 'RUNNING'}
     final_states = {'FINISHED', 'KILLED', 'FAILED'}

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,8 @@ setup_args = dict(
     ],
     extras_require={
         "kerberos": ['requests_kerberos'],
-        "yarn": ['requests', 'yarn-api-client'],
-        "k8s": ['kubernetes>=4.0.0', 'jinja2>=2.10'],
+        "yarn": ['yarn-api-client'],
+        "k8s": ['kubernetes>=18.20.0', 'jinja2>=3.1'],
         "docker": ['docker>=3.5.0'],
     },
     tests_require=[
@@ -113,7 +113,7 @@ setup_args = dict(
             'distributed-provisioner = remote_provisioners.distributed:DistributedProvisioner',
             'kubernetes-provisioner = remote_provisioners.k8s:KubernetesProvisioner',
             'docker-provisioner = remote_provisioners.docker_swarm:DockerProvisioner',
-            'docker_swarm-provisioner = remote_provisioners.docker_swarm:DockerSwarmProvisioner',
+            'docker-swarm-provisioner = remote_provisioners.docker_swarm:DockerSwarmProvisioner',
         ]
     },
     python_requires=">=3.6",


### PR DESCRIPTION
This pull request issues a warning message from the tools that require extra (optional) packages (e.g., kubernetes for the the k8s tool, yarn-api-client for the yarn tool, etc.) in case users have not installed remote_provisioners with the 'extras' argument.  It also catches ImportError in the respective provisioner and issues the same warning message prior to raising the error.

During this, I found the `impersonation_enabled` configurable was added at the wrong level of the hierarchy and fixed it.

(I also found that `--kernel-class-name` is not correct in many of the templates, and will fix that next.)