### PR TITLE
Fix kernel-class-name parameter in kernel-specs

### DIFF
--- a/remote_provisioners/kernel-specs/container_python/kernel.json
+++ b/remote_provisioners/kernel-specs/container_python/kernel.json
@@ -23,7 +23,7 @@
     "{response_address}",
     "--public-key",
     "{public_key}",
-    "--kernel_class_name",
+    "--kernel-class-name",
     "${ipykernel_subclass_name}"
   ]
 }

--- a/remote_provisioners/kernel-specs/k8s_python_spark/kernel.json
+++ b/remote_provisioners/kernel-specs/k8s_python_spark/kernel.json
@@ -24,7 +24,7 @@
     "{response_address}",
     "--spark-context-initialization-mode",
     "${spark_init_mode}",
-    "--kernel_class_name",
+    "--kernel-class-name",
     "${ipykernel_subclass_name}"
   ]
 }

--- a/remote_provisioners/kernel-specs/ssh_python/kernel.json
+++ b/remote_provisioners/kernel-specs/ssh_python/kernel.json
@@ -22,7 +22,7 @@
     "{response_address}",
     "--public-key",
     "{public_key}",
-    "--kernel_class_name",
+    "--kernel-class-name",
     "${ipykernel_subclass_name}"
   ]
 }

--- a/remote_provisioners/kernel-specs/yarn_dask_python/kernel.json
+++ b/remote_provisioners/kernel-specs/yarn_dask_python/kernel.json
@@ -26,7 +26,7 @@
     "{public_key}",
     "--cluster-type",
     "dask",
-    "--kernel_class_name",
+    "--kernel-class-name",
     "${ipykernel_subclass_name}"
   ]
 }

--- a/remote_provisioners/kernel-specs/yarn_spark_python/kernel.json
+++ b/remote_provisioners/kernel-specs/yarn_spark_python/kernel.json
@@ -27,7 +27,7 @@
     "{public_key}",
     "--spark-context-initialization-mode",
     "${spark_init_mode}",
-    "--kernel_class_name",
+    "--kernel-class-name",
     "${ipykernel_subclass_name}"
   ]
 }


### PR DESCRIPTION
When building the initial kernel-spec templates for this repo, I inadvertently used `--kernel_class_name` rather than `--kernel-class-name`.  This pull request adjusts the applicable (python) kernel-spec templates accordingly.