### PR TITLE
Detect missing toree jar and rscript executable, add overrides decorator

### DIFF
--- a/remote_provisioners/cli/docker_specapp.py
+++ b/remote_provisioners/cli/docker_specapp.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
+from overrides import overrides
 from traitlets import Bool, Unicode, default
 from traitlets.config.application import Application
 
@@ -78,8 +79,9 @@ enabled for Spark usage, this image will be the driver image. (RP_IMAGE_NAME env
     }
     flags.update(BaseSpecApp.super_flags)
 
+    @overrides
     def detect_missing_extras(self):
-        """Issues a warning message whenever an "extra" library is detected as missing."""
+        super().detect_missing_extras()
         try:
             import docker  # noqa: F401
         except ImportError:
@@ -89,8 +91,8 @@ enabled for Spark usage, this image will be the driver image. (RP_IMAGE_NAME env
                 "(e.g., pip install 'remote_provisioners[docker]')."
             )
 
+    @overrides
     def validate_parameters(self):
-        """Validate input parameters and prepare for their injection into templated files."""
         super().validate_parameters()
 
         self.language = self.language.lower()
@@ -112,8 +114,8 @@ enabled for Spark usage, this image will be the driver image. (RP_IMAGE_NAME env
         # sanitize kernel_name
         self.kernel_name = self.kernel_name.replace(" ", "_")
 
+    @overrides
     def get_substitutions(self, install_dir) -> dict:
-        """Gather substitution strings to inject into the templated files."""
         substitutions = super().get_substitutions(install_dir)
         substitutions["image_name"] = self.image_name
         substitutions["provisioner_name"] = self.provisioner_name

--- a/remote_provisioners/cli/k8s_specapp.py
+++ b/remote_provisioners/cli/k8s_specapp.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
+from overrides import overrides
 from traitlets import Bool, Unicode, default
 from traitlets.config.application import Application
 
@@ -93,8 +94,9 @@ Spark-enabled kernel specifications.  (RP_EXECUTOR_IMAGE_NAME env var)""",
     flags = {}
     flags.update(BaseSpecApp.super_flags)
 
+    @overrides
     def detect_missing_extras(self):
-        """Issues a warning message whenever an "extra" library is detected as missing."""
+        super().detect_missing_extras()
         try:
             import jinja2  # noqa: F401
             import kubernetes  # noqa: F401
@@ -105,8 +107,8 @@ Spark-enabled kernel specifications.  (RP_EXECUTOR_IMAGE_NAME env var)""",
                 "by specifying the extra 'k8s' (e.g., pip install 'remote_provisioners[k8s]')."
             )
 
+    @overrides
     def validate_parameters(self):
-        """Validate input parameters and prepare for their injection into templated files."""
         super().validate_parameters()
 
         self.language = self.language.lower()
@@ -148,8 +150,8 @@ Spark-enabled kernel specifications.  (RP_EXECUTOR_IMAGE_NAME env var)""",
         # sanitize kernel_name
         self.kernel_name = self.kernel_name.replace(" ", "_")
 
+    @overrides
     def get_substitutions(self, install_dir) -> dict:
-        """Gather substitution strings to inject into the templated files."""
         substitutions = super().get_substitutions(install_dir)
         substitutions["image_name"] = self.image_name
         substitutions["executor_image_name"] = self.executor_image_name

--- a/remote_provisioners/cli/ssh_specapp.py
+++ b/remote_provisioners/cli/ssh_specapp.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
+from overrides import overrides
 from traitlets import List, Unicode, default
 from traitlets.config.application import Application
 
@@ -69,8 +70,8 @@ each be specified via separate options: --remote-hosts host1 --remote-hosts host
     flags = {}
     flags.update(BaseSpecApp.super_flags)
 
+    @overrides
     def validate_parameters(self):
-        """Validate input parameters and prepare for their injection into templated files."""
         super().validate_parameters()
 
         self.language = self.language.lower()
@@ -103,14 +104,14 @@ each be specified via separate options: --remote-hosts host1 --remote-hosts host
         # sanitize kernel_name
         self.kernel_name = self.kernel_name.replace(" ", "_")
 
+    @overrides
     def add_optional_config_entries(self, config_stanza: dict) -> None:
-        """Adds optional configuration parameters to the 'config' stanza of 'kernel_provisioner'."""
         super().add_optional_config_entries(config_stanza)
         if self.remote_hosts and list(self.remote_hosts) != self.remote_hosts_default():
             config_stanza["remote_hosts"] = list(self.remote_hosts)
 
+    @overrides
     def get_substitutions(self, install_dir) -> dict:
-        """Gather substitution strings to inject into the templated files."""
         substitutions = super().get_substitutions(install_dir)
         substitutions["spark_master"] = self.spark_master
         return substitutions

--- a/remote_provisioners/cli/yarn_specapp.py
+++ b/remote_provisioners/cli/yarn_specapp.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+from overrides import overrides
 from traitlets import Bool, Unicode, default
 from traitlets.config.application import Application
 
@@ -142,8 +143,9 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
     }
     flags.update(BaseSpecApp.super_flags)
 
+    @overrides
     def detect_missing_extras(self):
-        """Issues a warning message whenever an "extra" library is detected as missing."""
+        super().detect_missing_extras()
         try:
             import yarn_api_client  # noqa: F401
         except ImportError:
@@ -153,8 +155,8 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
                 "extra 'yarn' (e.g., pip install 'remote_provisioners[yarn]')."
             )
 
+    @overrides
     def validate_parameters(self):
-        """Validate input parameters and prepare for their injection into templated files."""
         super().validate_parameters()
 
         entered_language = self.language
@@ -196,8 +198,8 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
         # sanitize kernel_name
         self.kernel_name = self.kernel_name.replace(" ", "_")
 
+    @overrides
     def add_optional_config_entries(self, config_stanza: dict) -> None:
-        """Adds optional configuration parameters to the 'config' stanza of 'kernel_provisioner'."""
         super().add_optional_config_entries(config_stanza)
         if self.yarn_endpoint and self.yarn_endpoint != self.yarn_endpoint_default():
             config_stanza["yarn_endpoint"] = self.yarn_endpoint
@@ -209,8 +211,8 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
         ):
             config_stanza["yarn_endpoint_security_enabled"] = self.yarn_endpoint_security_enabled
 
+    @overrides
     def get_substitutions(self, install_dir) -> dict:
-        """Gather substitution strings to inject into the templated files."""
         substitutions = super().get_substitutions(install_dir)
         substitutions["extra_dask_opts"] = self.extra_dask_opts
         substitutions["python_root"] = self.python_root


### PR DESCRIPTION
When installing scala-based kernels, we should look for and copy the Apache Toree jar file to the kernel spec's `lib` directory (alongside the launcher jar file).  This PR checks for:

1. Apache Toree is installed, and
2. That it contains ONE jar file in its `lib` directory that matches its version

If either of those is found not to be true, a context-sensitive warning will be issued but the kernelspec's installation will proceed and followed by a final instruction on where the Toree jar file needs to be placed prior to using the kernelspec.

Similarly for R-based kernels, we check that `Rscript` is in the current process's path and, if not, issue a warning that it will need to be present prior to running that kernelspec.

Since we need to call the super().detect_missing_extras() from the other commands, I added the `@overrides` decorator to improve maintainability to the various subclass methods.