### PR TITLE
Add ability to install bootstrap-kernel.sh and launchers from Dockerfile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ jupyter-k8s-spec = "remote_provisioners.cli.k8s_specapp:K8sProvisionerApp.launch
 jupyter-yarn-spec = "remote_provisioners.cli.yarn_specapp:YarnProvisionerApp.launch_instance"
 jupyter-ssh-spec = "remote_provisioners.cli.ssh_specapp:SshProvisionerApp.launch_instance"
 jupyter-docker-spec = "remote_provisioners.cli.docker_specapp:DockerProvisionerApp.launch_instance"
+jupyter-image-bootstrap = "remote_provisioners.cli.image_bootstrapapp:ImageBootstrapApp.launch_instance"
 
 [project.entry-points."jupyter_client.kernel_provisioners"]
 yarn-provisioner = "remote_provisioners.yarn:YarnProvisioner"

--- a/remote_provisioners/cli/docker_specapp.py
+++ b/remote_provisioners/cli/docker_specapp.py
@@ -7,7 +7,7 @@ from traitlets import Bool, Unicode, default
 from traitlets.config.application import Application
 
 from .._version import __version__
-from .base_specapp import DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
+from .base_app import DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
 
 DEFAULT_KERNEL_NAMES = {PYTHON: "docker_python", SCALA: "docker_scala", R: "docker_r"}
 KERNEL_SPEC_TEMPLATE_NAMES = {
@@ -23,7 +23,7 @@ SWARM_PROVISIONER_NAME = "docker-swarm-provisioner"
 LAUNCHER_NAME = "launch_docker.py"
 
 
-class DockerSpecApp(BaseSpecApp):
+class DockerSpecInstaller(BaseSpecApp):
     """CLI for extension management."""
 
     name = "jupyter-docker-spec"
@@ -67,13 +67,13 @@ enabled for Spark usage, this image will be the driver image. (RP_IMAGE_NAME env
     launcher_name = Unicode(LAUNCHER_NAME, config=False)
 
     aliases = {
-        "image-name": "DockerSpecApp.image_name",
+        "image-name": "DockerSpecInstaller.image_name",
     }
     aliases.update(BaseSpecApp.super_aliases)
 
     flags = {
         "swarm": (
-            {"DockerSpecApp": {"swarm": True}},
+            {"DockerSpecInstaller": {"swarm": True}},
             "Install kernel for use within a Docker Swarm cluster.",
         ),
     }
@@ -132,7 +132,10 @@ class DockerProvisionerApp(Application):
     via the KubernetesProvisioner kernel provisioner."""
     subcommands = dict(
         {
-            "install": (DockerSpecApp, DockerSpecApp.description.splitlines()[0]),
+            "install": (
+                DockerSpecInstaller,
+                DockerSpecInstaller.description.splitlines()[0],
+            ),
         }
     )
     aliases = {}

--- a/remote_provisioners/cli/image_bootstrapapp.py
+++ b/remote_provisioners/cli/image_bootstrapapp.py
@@ -1,0 +1,173 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+import shutil
+from string import Template
+from typing import Any
+
+from overrides import overrides
+from traitlets import List, TraitError, Unicode, validate
+from traitlets.config.application import Application
+
+from .._version import __version__
+from .base_app import (
+    PYTHON,
+    SCALA,
+    SUPPORTED_LANGUAGES,
+    BaseApp,
+    R,
+    kernel_launchers_dir,
+)
+
+LANG_DIR_NAMES = {PYTHON: "python", SCALA: "scala", R: "R"}
+BOOTSTRAP_FILE_NAME = "bootstrap-kernel.sh"
+
+
+class ImageBootstrapInstaller(BaseApp):
+    """CLI for extension management."""
+
+    name = "jupyter-image-bootstrap"
+    description = (
+        "Installs the bootstrap script and kernel launchers for use within a kernel "
+        "image used by Remote Provisioners."
+    )
+    # Note that the left justification of the second example is necessary to ensure proper
+    # alignment with the first example during --help output.
+    examples = """
+    jupyter-image-bootstrap install --languages=Python --languages=R --bootstrap-dir=/usr/local/share
+
+jupyter-image-bootstrap install --languages=Python --languages=Scala
+    """
+
+    languages = List(
+        Unicode(),
+        ["Python"],
+        config=True,
+        help="""The languages corresponding to the kernel-launchers to install into the kernel image.
+    All values must be one of 'Python', 'R', or 'Scala'.""",
+    )
+
+    @validate("languages")
+    def languages_validate(self, proposal: dict[str, Any]) -> List:
+        value = proposal["value"]
+        try:
+            for lang in value:
+                assert lang.lower() in SUPPORTED_LANGUAGES
+        except AssertionError:
+            raise TraitError(
+                f"Invalid languages value {value}, at least one of which is "
+                f"not in {SUPPORTED_LANGUAGES} (case-insensitive)"
+            )
+        return value
+
+    bootstrap_dir = Unicode(
+        "/usr/local/bin",
+        config=True,
+        help="Specifies the absolute directory within the kernel-image in which "
+        f"{BOOTSTRAP_FILE_NAME} should be installed.",
+    )
+
+    @validate("bootstrap_dir")
+    def bootstrap_dir_validate(self, proposal: dict[str, Any]) -> str:
+        value = proposal["value"]
+        try:
+            assert os.path.isabs(value)
+        except AssertionError:
+            raise TraitError(f"Invalid bootstrap_dir value!  '{value}' must be an absolute path.")
+        return value
+
+    aliases = {
+        "languages": "ImageBootstrapInstaller.languages",
+        "bootstrap-dir": "ImageBootstrapInstaller.bootstrap_dir",
+    }
+    aliases.update(BaseApp.aliases)
+
+    flags = {}
+    flags.update(BaseApp.flags)
+
+    kernel_spec_install = False  # Set to false when bootstrap installation occurs
+
+    @overrides
+    def detect_missing_extras(self):
+
+        for lang in self.languages:
+            if lang.lower() == SCALA:
+                self._detect_missing_toree_jar()
+            elif lang.lower() == R:
+                self._detect_missing_rscript()
+
+    @overrides
+    def install_files(self):
+        """Sets up the bootstrap-kernel.sh and corresponding kernel-launchers for use in kernel images"""
+
+        parent_dir = os.path.join(self.bootstrap_dir, "kernel-launchers")
+        for lang in self.languages:
+            lang_dir_name = LANG_DIR_NAMES.get(lang.lower())
+            target_dir = os.path.join(parent_dir, lang_dir_name)
+            self._copy_launcher_files(lang_dir_name, target_dir)
+            if lang_dir_name == SCALA and not self.toree_jar_path:
+                # If we're installing a scala kernel launcher and don't have the toree jar file, issue
+                # a warning indicating that the scala kernel needs that file in its kernel-launcher
+                # directory hierarchy.
+                kspec_toree_jar_location = os.path.join(target_dir, "lib")
+                self.log.warning(
+                    "The Apache Toree kernel is either not installed or it's jar file cannot be determined. "
+                    f"Please ensure that the Toree jar file is placed into '{kspec_toree_jar_location}' "
+                    f"prior to using the kernel image for scala."
+                )
+
+        bootstrap_file = os.path.join(kernel_launchers_dir, "bootstrap", BOOTSTRAP_FILE_NAME)
+        target_bootstrap_file = os.path.join(self.bootstrap_dir, BOOTSTRAP_FILE_NAME)
+        shutil.copyfile(bootstrap_file, target_bootstrap_file)
+        self._finalize_bootstrap(target_bootstrap_file)
+        self.log.info(
+            f"{BOOTSTRAP_FILE_NAME} and kernel-launcher files have been copied to {self.bootstrap_dir} "
+            f"and {parent_dir} for the following languages: {self.languages}."
+        )
+        self.log.info(
+            f"The CMD entry in the Dockerfile should be updated to: CMD {target_bootstrap_file}"
+        )
+
+    def _finalize_bootstrap(self, bootstrap_file: str):
+        subs = {"install_dir": self.bootstrap_dir}
+        bootstrap_str = ""
+        with open(bootstrap_file) as f:
+            for line in f:
+                bootstrap_str = bootstrap_str + line
+            f.close()
+        post_subs = Template(bootstrap_str).safe_substitute(subs)
+        with open(bootstrap_file, "w+") as f:
+            f.write(post_subs)
+
+
+class ImageBootstrapApp(Application):
+    """Application responsible for driving the creation of Kubernetes-based kernel specifications."""
+
+    version = __version__
+    name = "jupyter image-bootstrap"
+    description = """Application used to bootstrap kernel images with the appropriate
+kernel launchers for use by Remote Provisioners."""
+    subcommands = dict(
+        {
+            "install": (
+                ImageBootstrapInstaller,
+                ImageBootstrapInstaller.description.splitlines()[0],
+            ),
+        }
+    )
+    aliases = {}
+    flags = {}
+
+    def start(self):
+        if self.subapp is None:
+            print(f"No subcommand specified. Must specify one of: {list(self.subcommands)}")
+            print()
+            self.print_description()
+            self.print_subcommands()
+            self.exit(1)
+        else:
+            return self.subapp.start()
+
+
+if __name__ == "__main__":
+    ImageBootstrapInstaller.launch_instance()

--- a/remote_provisioners/cli/k8s_specapp.py
+++ b/remote_provisioners/cli/k8s_specapp.py
@@ -7,7 +7,7 @@ from traitlets import Bool, Unicode, default
 from traitlets.config.application import Application
 
 from .._version import __version__
-from .base_specapp import DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
+from .base_app import DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
 
 DEFAULT_KERNEL_NAMES = {PYTHON: "k8s_python", SCALA: "k8s_scala", R: "k8s_r"}
 KERNEL_SPEC_TEMPLATE_NAMES = {
@@ -30,7 +30,7 @@ PROVISIONER_NAME = "kubernetes-provisioner"
 LAUNCHER_NAME = "launch_kubernetes.py"
 
 
-class K8sSpecApp(BaseSpecApp):
+class K8sSpecInstaller(BaseSpecApp):
     """CLI for extension management."""
 
     name = "jupyter-k8s-spec"
@@ -86,8 +86,8 @@ Spark-enabled kernel specifications.  (RP_EXECUTOR_IMAGE_NAME env var)""",
     launcher_name = Unicode(LAUNCHER_NAME, config=False)
 
     aliases = {
-        "image-name": "K8sSpecApp.image_name",
-        "executor-image-name": "K8sSpecApp.executor_image_name",
+        "image-name": "K8sSpecInstaller.image_name",
+        "executor-image-name": "K8sSpecInstaller.executor_image_name",
     }
     aliases.update(BaseSpecApp.super_aliases)
 
@@ -169,7 +169,7 @@ class K8sProvisionerApp(Application):
     via the KubernetesProvisioner kernel provisioner."""
     subcommands = dict(
         {
-            "install": (K8sSpecApp, K8sSpecApp.description.splitlines()[0]),
+            "install": (K8sSpecInstaller, K8sSpecInstaller.description.splitlines()[0]),
         }
     )
     aliases = {}

--- a/remote_provisioners/cli/ssh_specapp.py
+++ b/remote_provisioners/cli/ssh_specapp.py
@@ -7,7 +7,7 @@ from traitlets import List, Unicode, default
 from traitlets.config.application import Application
 
 from .._version import __version__
-from .base_specapp import DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
+from .base_app import DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
 
 DEFAULT_KERNEL_NAMES = {PYTHON: "ssh_python", SCALA: "ssh_scala", R: "ssh_r"}
 DEFAULT_DISPLAY_NAMES = {PYTHON: "Python SSH", SCALA: "Scala SSH", R: "R SSH"}
@@ -15,7 +15,7 @@ SPARK_SUFFIX = "_spark"
 SPARK_DISPLAY_NAME_SUFFIX = " (with Spark)"
 
 
-class SshSpecApp(BaseSpecApp):
+class SshSpecInstaller(BaseSpecApp):
     """CLI for extension management."""
 
     name = "jupyter-ssh-spec"
@@ -62,8 +62,8 @@ each be specified via separate options: --remote-hosts host1 --remote-hosts host
     # Flags
 
     aliases = {
-        "remote-hosts": "SshSpecApp.remote_hosts",
-        "spark-master": "SshSpecApp.spark_master",
+        "remote-hosts": "SshSpecInstaller.remote_hosts",
+        "spark-master": "SshSpecInstaller.spark_master",
     }
     aliases.update(BaseSpecApp.super_aliases)
 
@@ -126,7 +126,7 @@ class SshProvisionerApp(Application):
     and the DistributedProvisioner kernel provisioner."""
     subcommands = dict(
         {
-            "install": (SshSpecApp, SshSpecApp.description.splitlines()[0]),
+            "install": (SshSpecInstaller, SshSpecInstaller.description.splitlines()[0]),
         }
     )
     aliases = {}

--- a/remote_provisioners/cli/yarn_specapp.py
+++ b/remote_provisioners/cli/yarn_specapp.py
@@ -8,7 +8,7 @@ from traitlets import Bool, Unicode, default
 from traitlets.config.application import Application
 
 from .._version import __version__
-from .base_specapp import DASK, DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
+from .base_app import DASK, DEFAULT_LANGUAGE, PYTHON, SCALA, BaseSpecApp, R
 
 DEFAULT_KERNEL_NAMES = {
     PYTHON: "yarn_spark_python",
@@ -24,7 +24,7 @@ DEFAULT_DISPLAY_NAMES = {
 }
 
 
-class YarnSpecApp(BaseSpecApp):
+class YarnSpecInstaller(BaseSpecApp):
     """CLI for extension management."""
 
     name = "jupyter-yarn-spec"
@@ -123,21 +123,24 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
     dask = Bool(False, config=True, help="Kernelspec will be configured for Dask YARN.")
 
     aliases = {
-        "yarn-endpoint": "YarnSpecApp.yarn_endpoint",
-        "alt-yarn-endpoint": "YarnSpecApp.alt_yarn_endpoint",
-        "python-root": "YarnSpecApp.python_root",
-        "extra-dask-opts": "YarnSpecApp.extra_dask_opts",
+        "yarn-endpoint": "YarnSpecInstaller.yarn_endpoint",
+        "alt-yarn-endpoint": "YarnSpecInstaller.alt_yarn_endpoint",
+        "python-root": "YarnSpecInstaller.python_root",
+        "extra-dask-opts": "YarnSpecInstaller.extra_dask_opts",
     }
     aliases.update(BaseSpecApp.super_aliases)
 
     flags = {
-        "dask": ({"YarnSpecApp": {"dask": True}}, "Install kernelspec for Dask in Yarn cluster."),
+        "dask": (
+            {"YarnSpecInstaller": {"dask": True}},
+            "Install kernelspec for Dask in Yarn cluster.",
+        ),
         "yarn-endpoint-security-enabled": (
-            {"YarnSpecApp": {"yarn_endpoint_security_enabled": True}},
+            {"YarnSpecInstaller": {"yarn_endpoint_security_enabled": True}},
             "Install kernelspec where Yarn API endpoint has security enabled.",
         ),
         "impersonation-enabled": (
-            {"YarnSpecApp": {"impersonation_enabled": True}},
+            {"YarnSpecInstaller": {"impersonation_enabled": True}},
             "Install kernelspec to impersonate user (requires root privileges).",
         ),
     }
@@ -240,7 +243,7 @@ class YarnProvisionerApp(Application):
     via the YarnProvisioner kernel provisioner."""
     subcommands = dict(
         {
-            "install": (YarnSpecApp, YarnSpecApp.description.splitlines()[0]),
+            "install": (YarnSpecInstaller, YarnSpecInstaller.description.splitlines()[0]),
         }
     )
     aliases = {}

--- a/remote_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh
+++ b/remote_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh
@@ -3,7 +3,7 @@
 PORT_RANGE=${PORT_RANGE:-${EG_PORT_RANGE:-0..0}}
 RESPONSE_ADDRESS=${RESPONSE_ADDRESS:-${EG_RESPONSE_ADDRESS}}
 PUBLIC_KEY=${PUBLIC_KEY:-${EG_PUBLIC_KEY}}
-KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-/usr/local/bin/kernel-launchers}
+KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-${install_dir}/kernel-launchers}
 KERNEL_SPARK_CONTEXT_INIT_MODE=${KERNEL_SPARK_CONTEXT_INIT_MODE:-none}
 
 echo $0 env: `env`
@@ -12,7 +12,7 @@ launch_python_kernel() {
     # Launch the python kernel launcher - which embeds the IPython kernel and listens for interrupts
     # and shutdown requests from Enterprise Gateway.
 
-    export JPY_PARENT_PID=$$  # Force reset of parent pid since we're detached
+    export JPY_PARENT_PID=$$$$  # Force reset of parent pid since we're detached
 
 	set -x
 	python ${KERNEL_LAUNCHERS_DIR}/python/scripts/launch_ipykernel.py --kernel-id ${KERNEL_ID} --port-range ${PORT_RANGE} --response-address ${RESPONSE_ADDRESS} --public-key ${PUBLIC_KEY} --spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}


### PR DESCRIPTION
Just like we have the ability to install kernel-spec files into the EG image from a `Dockerfile`, this pull request creates the CLI script: `jupyter image-bootstrap install` to copy the `bootstrap-kernel.sh` script and the applicable kernel-launcher hierarchies to the specified directory (which would reside in the target kernel image).

Here's the help output...
```
$ jupyter image-bootstrap install --help
Installs the bootstrap script and kernel launchers for use within a kernel image
used by Remote Provisioners.

Options
=======
The options below are convenience aliases to configurable class-options,
as listed in the "Equivalent to" description-line of the aliases.
To see all configurable class-options for some <cmd>, use:
    <cmd> --help-all

--debug
    set log level to logging.DEBUG (maximize logging output)
    Equivalent to: [--Application.log_level=10]
--show-config
    Show the application's configuration (human-readable format)
    Equivalent to: [--Application.show_config=True]
--show-config-json
    Show the application's configuration (json format)
    Equivalent to: [--Application.show_config_json=True]
--generate-config
    generate default config file
    Equivalent to: [--JupyterApp.generate_config=True]
-y
    Answer yes to any questions instead of prompting.
    Equivalent to: [--JupyterApp.answer_yes=True]
--languages=<list-item-1>...
    The languages corresponding to the kernel-launchers to install into the kernel image.
        All values must be one of 'Python', 'R', or 'Scala'.
    Default: ['Python']
    Equivalent to: [--ImageBootstrapInstaller.languages]
--bootstrap-dir=<Unicode>
    Specifies the absolute directory within the kernel-image in which bootstrap-
    kernel.sh should be installed.
    Default: '/usr/local/bin'
    Equivalent to: [--ImageBootstrapInstaller.bootstrap_dir]
--log-level=<Enum>
    Set the log level by value or name.
    Choices: any of [0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL']
    Default: 30
    Equivalent to: [--Application.log_level]
--config=<Unicode>
    Full path of a config file.
    Default: ''
    Equivalent to: [--JupyterApp.config_file]

Examples
--------

    jupyter-image-bootstrap install --languages=Python --languages=R --bootstrap-dir=/usr/local/share

    jupyter-image-bootstrap install --languages=Python --languages=Scala

To see all available configurables, use `--help-all`.
```

Here's the command's output...
```
jupyter bootstrap-image instal --languages R --languages Scala --languages python --bootstrap-dir /tmp/bin

[ImageBootstrapInstaller] bootstrap-kernel.sh and kernel-launcher files have been copied to /tmp/bin and /tmp/bin/kernel-launchers for the following languages: ['R', 'Scala', 'python'].
[ImageBootstrapInstaller] The CMD entry in the Dockerfile should be updated to: CMD /tmp/bin/bootstrap-kernel.sh
```