### PR TITLE
Remove use of future annotations to fix overrides

### DIFF
--- a/remote_provisioners/container.py
+++ b/remote_provisioners/container.py
@@ -1,12 +1,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Code related to managing kernels running in containers."""
-from __future__ import annotations
-
 import os
 import signal
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Optional
 
 import urllib3  # docker ends up using this and it causes lots of noise, so turn off warnings
 from jupyter_client import localinterfaces
@@ -116,7 +114,7 @@ class ContainerProvisionerBase(RemoteProvisionerBase):
         kwargs["env"]["KERNEL_GID"] = kernel_gid
 
     @overrides
-    async def poll(self) -> int | None:
+    async def poll(self) -> Optional[int]:
         """Determines if container is still active.
 
         Submitting a new kernel to the container manager will take a while to be Running.
@@ -231,7 +229,7 @@ class ContainerProvisionerBase(RemoteProvisionerBase):
         raise NotImplementedError
 
     @abstractmethod
-    async def get_container_status(self, iteration: str | None) -> str:
+    async def get_container_status(self, iteration: Optional[str]) -> str:
         """Return current container state."""
         raise NotImplementedError
 

--- a/remote_provisioners/distributed.py
+++ b/remote_provisioners/distributed.py
@@ -1,8 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Code related to managing kernels running in YARN clusters."""
-from __future__ import annotations
-
 import asyncio
 import getpass
 import json
@@ -11,7 +9,7 @@ import signal
 import subprocess
 import warnings
 from socket import gethostbyname, gethostname
-from typing import Any
+from typing import Any, Optional
 
 import paramiko
 from jupyter_client import KernelConnectionInfo, launch_kernel
@@ -46,7 +44,7 @@ class TrackKernelOnHost:
             self.decrement(host)
             del self._kernel_host_mapping[kernel_id]
 
-    def min_or_remote_host(self, remote_host: str | None = None) -> str:
+    def min_or_remote_host(self, remote_host: Optional[str] = None) -> str:
         if remote_host:
             return remote_host
         return min(self._host_kernels, key=lambda k: self._host_kernels[k])
@@ -167,7 +165,7 @@ class DistributedProvisioner(RemoteProvisionerBase):
         return self.connection_info
 
     @overrides
-    async def poll(self) -> int | None:
+    async def poll(self) -> Optional[int]:
         signal_delivered = await self._send_signal_via_listener(0)
         if signal_delivered:  # kernel process still alive, return None
             return None

--- a/remote_provisioners/docker_swarm.py
+++ b/remote_provisioners/docker_swarm.py
@@ -1,11 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Code related to managing kernels running in docker-based containers."""
-from __future__ import annotations
-
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 from overrides import overrides
 from traitlets import validate
@@ -64,7 +62,7 @@ class DockerSwarmProvisioner(ContainerProvisionerBase):
         return {"preparing", "starting", "running"}
 
     @overrides
-    async def get_container_status(self, iteration: str | None) -> str:
+    async def get_container_status(self, iteration: Optional[str]) -> str:
         # Locates the kernel container using the kernel_id filter.  If the status indicates an initial state we
         # should be able to get at the NetworksAttachments and determine the associated container's IP address.
         task_state = None
@@ -96,7 +94,7 @@ class DockerSwarmProvisioner(ContainerProvisionerBase):
         return task_state
 
     @overrides
-    async def terminate_container_resources(self, restart: bool = False) -> bool | None:
+    async def terminate_container_resources(self, restart: bool = False) -> Optional[bool]:
         # Remove the docker service.
 
         result = True  # We'll be optimistic
@@ -196,7 +194,7 @@ class DockerProvisioner(ContainerProvisionerBase):
         return {"created", "running"}
 
     @overrides
-    async def get_container_status(self, iteration: str | None) -> str:
+    async def get_container_status(self, iteration: Optional[str]) -> str:
         # Locates the kernel container using the kernel_id filter.  If the phase indicates Running, the pod's IP
         # is used for the assigned_ip.  Only used when docker mode == regular (non swarm)
         container_status = None

--- a/remote_provisioners/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/remote_provisioners/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -1,7 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from __future__ import annotations
-
 import argparse
 import logging
 import os
@@ -9,7 +7,7 @@ import signal
 import tempfile
 from collections.abc import Callable
 from threading import Thread
-from typing import Any
+from typing import Any, Optional
 
 from server_listener import setup_server_listener
 
@@ -151,7 +149,7 @@ class WaitingForSparkSessionToBeInitialized:
             return getattr(self._namespace[self._spark_session_variable], name)
 
 
-def _validate_port_range(port_range: str | None) -> tuple[int, int]:
+def _validate_port_range(port_range: Optional[str]) -> tuple[int, int]:
     # if no argument was provided, return a range of 0
     if not port_range:
         return 0, 0

--- a/remote_provisioners/kernel-launchers/python/scripts/server_listener.py
+++ b/remote_provisioners/kernel-launchers/python/scripts/server_listener.py
@@ -6,7 +6,7 @@
 # assembly.  The file is also used by the launch_IRkernel.R script, but it does not require a
 # placeholder to satisfy references due to the language differences.
 #
-from __future__ import annotations
+from typing import Optional
 
 
 def setup_server_listener(
@@ -17,7 +17,7 @@ def setup_server_listener(
     response_addr: str,
     kernel_id: str,
     public_key: str,
-    cluster_type: str | None = None,
-    as_thread: bool | None = True,
+    cluster_type: Optional[str] = None,
+    as_thread: Optional[bool] = True,
 ):
     raise NotImplementedError("kernel-launcher assembly is required!")

--- a/remote_provisioners/kernel-launchers/shared/scripts/server_listener.py
+++ b/remote_provisioners/kernel-launchers/shared/scripts/server_listener.py
@@ -1,7 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from __future__ import annotations
-
 import base64
 import json
 import logging
@@ -11,7 +9,7 @@ import signal
 import socket
 import uuid
 from multiprocessing import Process, set_start_method
-from typing import Any
+from typing import Any, Optional
 
 from Cryptodome.Cipher import AES, PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
@@ -46,7 +44,7 @@ class ServerListener:
         response_addr: str,
         kernel_id: str,
         public_key: str,
-        cluster_type: str | None = None,
+        cluster_type: Optional[str] = None,
     ):
         # Note, in the R integration, parameters come into Python as strings, so
         # we need to explicitly cast non-strings.
@@ -191,7 +189,7 @@ class ServerListener:
         """Gets a request from the server and returns the corresponding dictionary."""
         conn: socket = None
         data: str = ""
-        request_info: dict | None = None
+        request_info: Optional[dict] = None
         try:
             conn, addr = self.comm_socket.accept()
             while True:
@@ -262,7 +260,7 @@ def setup_server_listener(
     response_addr: str,
     kernel_id: str,
     public_key: str,
-    cluster_type: str | None = None,
+    cluster_type: Optional[str] = None,
 ) -> None:
     """Initializes the server listener sub-process to handle requests from the server."""
 

--- a/remote_provisioners/remote_provisioner.py
+++ b/remote_provisioners/remote_provisioner.py
@@ -1,8 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Kernel managers that operate against a remote process."""
-from __future__ import annotations
-
 import asyncio
 import errno
 import getpass
@@ -15,7 +13,7 @@ import time
 from abc import abstractmethod
 from enum import Enum
 from socket import AF_INET, SHUT_WR, SOCK_STREAM, socket, timeout
-from typing import Any
+from typing import Any, Optional
 
 import pexpect
 from jupyter_client import (
@@ -160,11 +158,11 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
 
     @abstractmethod
     @overrides
-    async def poll(self) -> int | None:
+    async def poll(self) -> Optional[int]:
         pass
 
     @overrides
-    async def wait(self) -> int | None:
+    async def wait(self) -> Optional[int]:
         # If we have a local_proc, call its wait method.  This will cleanup any defunct processes when the kernel
         # is shutdown (when using waitAppCompletion = false).  Otherwise (if no local_proc) we'll use polling to
         # determine if a (remote or revived) process is still active.
@@ -244,7 +242,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         self.tunneled_connect_info = provisioner_info.get("tunneled_connect_info")
 
     @overrides
-    def get_shutdown_wait_time(self, recommended: float | None = 5.0) -> float:
+    def get_shutdown_wait_time(self, recommended: Optional[float] = 5.0) -> float:
         return recommended
 
     @overrides
@@ -323,7 +321,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
                 self.local_proc = None
                 self.log_and_raise(RuntimeError(error_message))
 
-    def log_and_raise(self, ex: Exception, chained: Exception | None = None) -> None:
+    def log_and_raise(self, ex: Exception, chained: Optional[Exception] = None) -> None:
         """Helper method that logs the stringized exception 'ex' and raises that exception.
 
         If a chained exception is provided that exception will be in the raised exceptions's from clause.
@@ -682,7 +680,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
                 self.local_proc = None
 
     async def _send_listener_request(
-        self, request: dict, shutdown_socket: bool | None = False
+        self, request: dict, shutdown_socket: Optional[bool] = False
     ) -> None:
         """
         Sends the request dictionary to the kernel listener via the comm port.  Caller is responsible for
@@ -725,7 +723,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
             )
 
     def _tunnel_to_kernel(
-        self, connection_info: dict, server: str, port: int = ssh_port, key: str | None = None
+        self, connection_info: dict, server: str, port: int = ssh_port, key: Optional[str] = None
     ):
         """
         Tunnel connections to a kernel over SSH
@@ -776,7 +774,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         remote_port: int,
         server: str,
         port: int = ssh_port,
-        key: str | None = None,
+        key: Optional[str] = None,
     ):
         """
         Analogous to _tunnel_to_kernel, but deals with a single port.  This will typically be called for
@@ -797,7 +795,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         remote_ip: str,
         server: str,
         port: int,
-        key: str | None = None,
+        key: Optional[str] = None,
     ):
         """
         Creates an SSH tunnel between the local and remote port/server for the given kernel channel.
@@ -827,7 +825,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         remote_ip: str,
         server: str,
         port: int,
-        key: str | None = None,
+        key: Optional[str] = None,
     ):
         """
         This method spawns a child process to create an SSH tunnel and returns the spawned process.

--- a/remote_provisioners/yarn.py
+++ b/remote_provisioners/yarn.py
@@ -1,8 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """Code related to managing kernels running in YARN clusters."""
-from __future__ import annotations
-
 import asyncio
 import errno
 import logging
@@ -10,7 +8,7 @@ import os
 import signal
 import socket
 import time
-from typing import Any
+from typing import Any, Optional
 
 from overrides import overrides
 from traitlets import Bool, Unicode, default
@@ -134,7 +132,7 @@ class YarnProvisioner(RemoteProvisionerBase):
         return kwargs
 
     @overrides
-    def get_shutdown_wait_time(self, recommended: float | None = 5.0) -> float:
+    def get_shutdown_wait_time(self, recommended: Optional[float] = 5.0) -> float:
         # YARN applications tend to take longer than the default 5 second wait time.  Rather than
         # require a command-line option for those using YARN, we'll adjust based on a local env that
         # defaults to 15 seconds.  Note: we'll only adjust if the current wait time is shorter than
@@ -148,7 +146,7 @@ class YarnProvisioner(RemoteProvisionerBase):
         return recommended
 
     @overrides
-    async def poll(self) -> int | None:
+    async def poll(self) -> Optional[int]:
         # Submitting a new kernel/app to YARN will take a while to be ACCEPTED.
         # Thus application ID will probably not be available immediately for poll.
         # So will regard the application as RUNNING when application ID still in ACCEPTED or SUBMITTED state.
@@ -308,7 +306,7 @@ class YarnProvisioner(RemoteProvisionerBase):
             timeout_message = f"KernelID: '{self.kernel_id}' launch timeout due to: {reason}"
             self.log_and_raise(TimeoutError(timeout_message))
 
-    async def _shutdown_application(self) -> tuple[bool | None, str]:
+    async def _shutdown_application(self) -> tuple[Optional[bool], str]:
         """Shuts down the YARN application, returning None if final state is confirmed, False otherwise."""
         result = False
         self._kill_app_by_id(self.application_id)
@@ -430,7 +428,7 @@ class YarnProvisioner(RemoteProvisionerBase):
             reason = f"Yarn Compute Resource is unavailable after {self.yarn_resource_check_wait_time} seconds"
             self.log_and_raise(TimeoutError(reason))
 
-    def _initialize_resource_manager(self, **kwargs: dict[str, Any] | None) -> None:
+    def _initialize_resource_manager(self, **kwargs: Optional[dict[str, Any]]) -> None:
         """Initialize the Hadoop YARN Resource Manager instance used for this kernel's lifecycle."""
 
         endpoints = None
@@ -485,7 +483,7 @@ class YarnProvisioner(RemoteProvisionerBase):
 
         return app_state
 
-    def _get_application_id(self, ignore_final_states: bool = False) -> str | None:
+    def _get_application_id(self, ignore_final_states: bool = False) -> Optional[str]:
         """
         Return the kernel's YARN application ID if available, otherwise None.
 
@@ -516,7 +514,7 @@ class YarnProvisioner(RemoteProvisionerBase):
                 )
         return self.application_id
 
-    def _query_app_by_name(self, kernel_id: str) -> dict | None:
+    def _query_app_by_name(self, kernel_id: str) -> Optional[dict]:
         """
         Retrieve application by using kernel_id as the unique app name.
 
@@ -560,7 +558,7 @@ class YarnProvisioner(RemoteProvisionerBase):
                         top_most_app_id = app.get("id")
         return target_app
 
-    def _query_app_by_id(self, app_id: str) -> dict | None:
+    def _query_app_by_id(self, app_id: str) -> Optional[dict]:
         """Retrieve an application by application ID.
 
         :param app_id


### PR DESCRIPTION
The `overrides` package will be strict regarding method signatures of decorated (`@overrides`) methods.  When running in Python 3.10, if an overridden method has a return type of `int | None` but the superclass definition uses `Optional[int]`, the following exception will be thrown (only on Python 3.10) during the _load_ of the application:
```bash
$ jupyter image-bootstrap install --languages Python --languages Scala
Traceback (most recent call last):
  File "/opt/miniconda3/envs/py3.10/bin/jupyter-image-bootstrap", line 5, in <module>
    from remote_provisioners.cli.image_bootstrapapp import ImageBootstrapApp
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/remote_provisioners/__init__.py", line 1, in <module>
    from .remote_provisioner import RemoteProvisionerBase
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/remote_provisioners/remote_provisioner.py", line 73, in <module>
    class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase):
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/remote_provisioners/remote_provisioner.py", line 167, in RemoteProvisionerBase
    async def wait(self) -> int | None:
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/overrides/overrides.py", line 88, in overrides
    return _overrides(method, check_signature, check_at_runtime)
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/overrides/overrides.py", line 115, in _overrides
    _validate_method(method, super_class, check_signature)
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/overrides/overrides.py", line 136, in _validate_method
    ensure_signature_is_compatible(super_method, method, is_static)
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/overrides/signature.py", line 102, in ensure_signature_is_compatible
    ensure_return_type_compatibility(super_type_hints, sub_type_hints, method_name)
  File "/opt/miniconda3/envs/py3.10/lib/python3.10/site-packages/overrides/signature.py", line 302, in ensure_return_type_compatibility
    raise TypeError(
TypeError: RemoteProvisionerBase.wait: return type `int | None` is not a `typing.Optional[int]`.
```

Since these return types should be equivalent, this seems like an issue in `overrides`.  At any rate, this PR removes the use of `annotations` from the `__future__` module and restores the use of `Optional[]` in all locations - not just those where mismatches were detected.